### PR TITLE
AIV-783: Settings to publish to bintray

### DIFF
--- a/project/HmrcBuild.scala
+++ b/project/HmrcBuild.scala
@@ -18,6 +18,7 @@ import sbt.Keys._
 import sbt._
 import uk.gov.hmrc.versioning.SbtGitVersioning
 import uk.gov.hmrc.versioning.SbtGitVersioning.autoImport.majorVersion
+import uk.gov.hmrc.SbtArtifactory.autoImport.makePublicallyAvailableOnBintray
 
 object HmrcBuild extends Build {
 
@@ -35,6 +36,7 @@ object HmrcBuild extends Build {
         Resolver.url("HMRC Sbt Plugin Releases", url("https://dl.bintray.com/hmrc/sbt-plugin-releases"))(Resolver.ivyStylePatterns),
         "HMRC Releases" at "https://dl.bintray.com/hmrc/releases"
       ),
+      makePublicallyAvailableOnBintray := true,
       majorVersion := 0
 
   )


### PR DESCRIPTION
See https://confluence.tools.tax.service.gov.uk/display/PLATOPS/Migrate+services+and+libraries+to+new+Build
Section 4. Public libraries ONLY. DO NOT use on microservices